### PR TITLE
Search for directory instead of file and omit NA in predicate$key

### DIFF
--- a/R/occQuery.R
+++ b/R/occQuery.R
@@ -101,7 +101,7 @@ occQuery <- function(x = NULL,
     GBIFDownloadDirectory <- getwd();
   }
 
-  if(!file.exists(GBIFDownloadDirectory)){
+  if(!dir.exists(GBIFDownloadDirectory)){
     warning("You have specified a non-existant location for your GBIF data downloads.\n");
     return(NULL);
   }

--- a/R/prevGBIFdownload.R
+++ b/R/prevGBIFdownload.R
@@ -31,7 +31,7 @@ prevGBIFdownload <- function(taxonKey, GBIFLogin){
     if(!is.na(dl$results$request.predicate.key[i]) &
        dl$results$request.predicate.key[i]=="TAXON_KEY"){
       recKey <- dl$results$request.predicate.value[i];
-    } else if (any(dl$results$request.predicate.predicates[[i]]$key=="TAXON_KEY")) {
+    } else if (any(na.omit(dl$results$request.predicate.predicates[[i]]$key=="TAXON_KEY"))) {
       recKey <- dl$results$request.predicate.predicates[[i]][
         dl$results$request.predicate.predicates[[i]]$key=="TAXON_KEY",]$value;
     }


### PR DESCRIPTION
I was having issues to run the example. This change fixed the problems:
1. In occQuery, it was looking for a file instead of the directory.
2. For a weird reason, my personal GBIF account has some NAs in predicate$key. This resulted in NA instead of a logical value.

Best,
Gonzalo