### PR TITLE
Incorporate new predicate method and adding fields required on Wallace

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -33,6 +33,7 @@ Imports:
     stringr,
     stats,
     knitr,
-    bit64
+    bit64,
+    rnaturalearth
 VignetteBuilder: knitr
 RoxygenNote: 7.0.0

--- a/R/GBIFLoginManager.R
+++ b/R/GBIFLoginManager.R
@@ -53,7 +53,8 @@ GBIFLoginManager <- function(user = NULL, email = NULL, pwd = NULL) {
   pwd <- check_pwd(pwd)
 
   #Test login
-  test <- try(rgbif::occ_download(user=user, email = email, pwd = pwd, "catalogNumber = Bird.27847588"), silent = T);
+  test <- try(rgbif::occ_download(user=user, email = email, pwd = pwd,
+                                  rgbif::pred("catalogNumber", "Bird.27847588")), silent = T);
   if(class(test) != 'occ_download'){
     warning("GBIF user login data incorrect.\n");
     return(NULL);

--- a/R/getGBIFpoints.R
+++ b/R/getGBIFpoints.R
@@ -39,10 +39,12 @@ getGBIFpoints<-function(taxon, GBIFLogin = GBIFLogin, GBIFDownloadDirectory = GB
   }
 
   if(checkPreviousGBIFDownload == F | (checkPreviousGBIFDownload == T && is.null(occD))) {
-    occD <- rgbif::occ_download(paste("taxonKey = ", key, sep = ""),
-                         "hasCoordinate = true", "hasGeospatialIssue = false",
-                         user = GBIFLogin@username, email = GBIFLogin@email,
-                         pwd = GBIFLogin@pwd);
+    occD <- rgbif::occ_download(rgbif::pred("taxonKey", key),
+                                rgbif::pred("hasCoordinate", TRUE),
+                                rgbif::pred("hasGeospatialIssue", FALSE),
+                                user = GBIFLogin@username,
+                                email = GBIFLogin@email,
+                                pwd = GBIFLogin@pwd);
 
     print(paste0("It is: ", format(Sys.time(), format = "%H:%M:%S"), ". Please be patient while GBIF prepares your download for ", taxon, ". This can take some time."));
     while (rgbif::occ_download_meta(occD[1])$status != "SUCCEEDED"){

--- a/R/tabGBIF.R
+++ b/R/tabGBIF.R
@@ -34,14 +34,23 @@ tabGBIF <- function(GBIFresults, taxon){
                             occFromGBIF$decimalLatitude,
                             occFromGBIF$day, occFromGBIF$month,
                             occFromGBIF$year, occFromGBIF$datasetID,
-                            as.character(occFromGBIF$datasetKey))
+                            as.character(occFromGBIF$datasetKey),
+                            occFromGBIF$countryCode,
+                            occFromGBIF$stateProvince,
+                            occFromGBIF$locality,
+                            occFromGBIF$basisOfRecord,
+                            occFromGBIF$catalogNumber,
+                            occFromGBIF$institutionCode,
+                            occFromGBIF$elevation,
+                            occFromGBIF$coordinateUncertaintyInMeters)
   dataService <- rep("GBIF", nrow(occFromGBIF));
   occFromGBIF <- cbind(occFromGBIF, dataService);
   occFromGBIF <- occFromGBIF[stats::complete.cases(occFromGBIF[,-8]),]# "Dataset" column excluded because it is not always filled out, but is useful for quick human checks
 
-  colnames(occFromGBIF) <- c("gbifID", "name", "longitude",
-                             "latitude", "day", "month",
-                             "year", "Dataset",
-                             "DatasetKey", "DataService");
+  colnames(occFromGBIF) <- c("gbifID", "name", "longitude", "latitude", "day",
+                             "month", "year", "Dataset", "DatasetKey", "DataService",
+                             "country", "stateProvince", "locality", "basisOfRecord",
+                             "catalogNumber", "institutionCode", "elevation",
+                             "coordinateUncertaintyInMeters")
   return(occFromGBIF)
 }

--- a/R/tabGBIF.R
+++ b/R/tabGBIF.R
@@ -48,9 +48,9 @@ tabGBIF <- function(GBIFresults, taxon){
   occFromGBIF <- occFromGBIF[stats::complete.cases(occFromGBIF[,-8]),]# "Dataset" column excluded because it is not always filled out, but is useful for quick human checks
 
   colnames(occFromGBIF) <- c("gbifID", "name", "longitude", "latitude", "day",
-                             "month", "year", "Dataset", "DatasetKey", "DataService",
-                             "country", "stateProvince", "locality", "basisOfRecord",
+                             "month", "year", "Dataset", "DatasetKey", "country",
+                             "stateProvince", "locality", "basisOfRecord",
                              "catalogNumber", "institutionCode", "elevation",
-                             "coordinateUncertaintyInMeters")
+                             "coordinateUncertaintyInMeters", "DataService")
   return(occFromGBIF)
 }

--- a/inst/extdata/sampleScript.R
+++ b/inst/extdata/sampleScript.R
@@ -10,7 +10,6 @@ GBIFLogin <- GBIFLoginManager(user = "userName",
 myOccCiteObject <- occQuery(x = "Protea cynaroides",
                             GBIFLogin = GBIFLogin,
                             datasources = c("gbif", "bien"),
-                            GBIFDownloadDirectory = "~/Desktop",
                             loadLocalGBIFDownload = F,
                             checkPreviousGBIFDownload = F);
 


### PR DESCRIPTION
Hi Hannah,

The new version of rgbif is using a predicate method in its functions, which means that occCite functions were not working. I made some changes in the code to make occCite to work on Wallace (I'm not sure if you need to make more changes for other functions). Also, I added some fields that we use on Wallace.

Let me know if you need some clarification.

Best,
Gonzalo