### PR TITLE
expanded functionality for occCite mapping

### DIFF
--- a/R/occCite_plotting.R
+++ b/R/occCite_plotting.R
@@ -19,8 +19,8 @@ tabulate.occResults <- function(x, sp.name) {
   occTbls <- lapply(x, function(db) db$OccurrenceTable)
   occTbls.nulls <- sapply(occTbls, is.null)
   occTbls.char <- lapply(occTbls[!occTbls.nulls], function(tbl)
-    tbl %>% dplyr::mutate_if(is.factor, as.character)
-    %>% dplyr::mutate(name = sp.name))
+    tbl %>% dplyr::mutate_if(is.factor, as.character) %>%
+      dplyr::mutate(name = sp.name))
   occTbls.bind <- dplyr::bind_rows(occTbls.char)
   return(occTbls.bind)
 }

--- a/man/map.occCite.Rd
+++ b/man/map.occCite.Rd
@@ -4,20 +4,52 @@
 \alias{map.occCite}
 \title{Generating a map of downloaded points}
 \usage{
-map.occCite(occCiteData, cluster = FALSE)
+map.occCite(
+  occCiteData,
+  species_map = "all",
+  species_colors = NULL,
+  ds_map = c("GBIF", "BIEN"),
+  map_limit = 1000,
+  awesomeMarkers = TRUE,
+  cluster = FALSE
+)
 }
 \arguments{
-\item{occCiteData}{An object of class \code{\link{occCiteData}} to
-map.}
+\item{occCiteData}{An object of class \code{\link{occCiteData}} to map}
 
-\item{cluster}{Logical; setting to `TRUE` turns on marker clustering.}
+\item{species_map}{Character; either the default "all" to map all species
+in occCiteData, or a subset of these specified as a character or character vector}
+
+\item{species_colors}{Character; the default NULL will choose random colors from
+those available (see Details), or those specified by the user as
+a character or character vector (the number of colors must match the number of species mapped)}
+
+\item{ds_map}{Character; specifies which DataService records will be mapped, with the default
+being GBIF, BIEN, and GBIF_BIEN (records with the same coordinates in both databases)}
+
+\item{map_limit}{Numeric; the number of points to map per species, set at a default of 1000
+randomly selected records; users can specify a higher number, but be aware that leaflet can
+lag or crash when too many points are plotted}
+
+\item{awesomeMarkers}{Logical; if `TRUE` (default), mapped points will be awesomeMarkers
+attributed with an icon for a globe for GBIF, a leaf for BIEN, or a database if records
+from both databases have the same coordinates; if `FALSE`, mapped points will be leaflet circleMarkers}
+
+\item{cluster}{Logical; if `TRUE` (default is `FALSE`) turns on marker clustering, which does not
+preserve color differences between species}
 }
 \value{
-A GBIF download key, if one is available
+A leaflet map
 }
 \description{
 Makes maps for each individual species in an occCite
 data object.
+}
+\details{
+When mapping awesomeMarkers (default), the parameter species_colors must match those in
+a specified color library, currently: c("red", "lightred", "orange", "beige", "green", "lightgreen",
+"blue", "lightblue", "purple", "pink", "cadetblue", "white", "gray", "lightgray"). When awesomeMarkers
+if `FALSE` and species_colors are not specified, random colors from the RColorBrewer Set1 palette are used.
 }
 \examples{
 \donttest{


### PR DESCRIPTION
I reintegrated the old unmerged pull request changes I made and added some more functionality. Now you can:
1. symbolize records by dataService, whether GBIF, BIEN, or both (records shared across databases) using awesomeMarkers (which have limited colors to choose from)
2. turn off awesomeMarkers and use your own colors for leaflet circleMarkers
3. map only a certain dataService (or only shared records)
4. by default, to avoid leaflet crashing with big data, restrict mapping to a random 1000 records for each species (this can be changed)